### PR TITLE
iOS Home widget: implement UI/data provider, add Info.plist fix, and set extension bundle identifier

### DIFF
--- a/ios/MemoHomeWidget/Info.plist
+++ b/ios/MemoHomeWidget/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>NSExtension</key>
 	<dict>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).MemoHomeWidget</string>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.widgetkit-extension</string>
 	</dict>

--- a/ios/MemoHomeWidget/MemoHomeWidget.swift
+++ b/ios/MemoHomeWidget/MemoHomeWidget.swift
@@ -8,50 +8,221 @@
 import WidgetKit
 import SwiftUI
 
-struct Provider: AppIntentTimelineProvider {
-    func placeholder(in context: Context) -> SimpleEntry {
-        SimpleEntry(date: Date(), configuration: ConfigurationAppIntent())
-    }
+private enum WidgetConstants {
+    static let appGroupId = "group.com.ttperry.handnote"
+    static let memoListKey = "memo_list"
+    static let statusListKey = "status_list"
+    static let maxCardsForSmall = 1
+}
 
-    func snapshot(for configuration: ConfigurationAppIntent, in context: Context) async -> SimpleEntry {
-        SimpleEntry(date: Date(), configuration: configuration)
-    }
-    
-    func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<SimpleEntry> {
-        var entries: [SimpleEntry] = []
-
-        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
-        let currentDate = Date()
-        for hourOffset in 0 ..< 5 {
-            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
-            let entry = SimpleEntry(date: entryDate, configuration: configuration)
-            entries.append(entry)
+private struct MemoHomeWidgetDataProvider {
+    static func loadEntry(isPreview: Bool = false) -> MemoWidgetEntry {
+        if isPreview {
+            return MemoWidgetEntry(date: Date(), memos: sampleMemos, statuses: sampleStatuses)
         }
 
-        return Timeline(entries: entries, policy: .atEnd)
+        let memos = loadMemos()
+        let statuses = loadStatuses()
+        return MemoWidgetEntry(date: Date(), memos: memos, statuses: statuses)
     }
 
-//    func relevances() async -> WidgetRelevances<ConfigurationAppIntent> {
-//        // Generate a list containing the contexts this widget is relevant in.
-//    }
+    static func loadMemos() -> [MemoItem] {
+        guard let defaults = UserDefaults(suiteName: WidgetConstants.appGroupId),
+              let jsonString = defaults.string(forKey: WidgetConstants.memoListKey),
+              let data = jsonString.data(using: .utf8) else {
+            return []
+        }
+
+        return (try? JSONDecoder().decode([MemoItem].self, from: data)) ?? []
+    }
+
+    static func loadStatuses() -> [StatusItem] {
+        guard let defaults = UserDefaults(suiteName: WidgetConstants.appGroupId),
+              let jsonString = defaults.string(forKey: WidgetConstants.statusListKey),
+              let data = jsonString.data(using: .utf8) else {
+            return []
+        }
+
+        return (try? JSONDecoder().decode([StatusItem].self, from: data)) ?? []
+    }
+
+    private static var sampleMemos: [MemoItem] {
+        [
+            MemoItem(memoId: 101, content: "買い物メモを作成する", statusId: 2, prevStatusId: 2),
+            MemoItem(memoId: 102, content: "週末の旅行プランを整理する", statusId: 3, prevStatusId: 3),
+            MemoItem(memoId: 103, content: "読書リストを更新", statusId: 2, prevStatusId: 2)
+        ]
+    }
+
+    private static var sampleStatuses: [StatusItem] {
+        [
+            StatusItem(statusId: 1, sortNo: 1, statusNm: "完了", statusColor: "#4CAF50"),
+            StatusItem(statusId: 2, sortNo: 2, statusNm: "進行中", statusColor: "#FF9800"),
+            StatusItem(statusId: 3, sortNo: 3, statusNm: "未着手", statusColor: "#9C27B0")
+        ]
+    }
 }
 
-struct SimpleEntry: TimelineEntry {
+struct Provider: AppIntentTimelineProvider {
+    func placeholder(in context: Context) -> MemoWidgetEntry {
+        MemoHomeWidgetDataProvider.loadEntry(isPreview: true)
+    }
+
+    func snapshot(for configuration: ConfigurationAppIntent, in context: Context) async -> MemoWidgetEntry {
+        MemoHomeWidgetDataProvider.loadEntry(isPreview: context.isPreview)
+    }
+
+    func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<MemoWidgetEntry> {
+        let entry = MemoHomeWidgetDataProvider.loadEntry()
+        return Timeline(entries: [entry], policy: .never)
+    }
+}
+
+struct MemoWidgetEntry: TimelineEntry {
     let date: Date
-    let configuration: ConfigurationAppIntent
+    let memos: [MemoItem]
+    let statuses: [StatusItem]
 }
 
-struct MemoHomeWidgetEntryView : View {
+struct MemoItem: Decodable, Identifiable {
+    let memoId: Int
+    let content: String
+    let statusId: Int
+    let prevStatusId: Int
+
+    var id: Int { memoId }
+}
+
+struct StatusItem: Decodable {
+    let statusId: Int
+    let sortNo: Int
+    let statusNm: String
+    let statusColor: String
+}
+
+struct MemoHomeWidgetEntryView: View {
+    @Environment(\.widgetFamily) private var family
     var entry: Provider.Entry
 
     var body: some View {
-        VStack {
-            Text("Time:")
-            Text(entry.date, style: .time)
+        let statusMap = Dictionary(uniqueKeysWithValues: entry.statuses.map { ($0.statusId, $0) })
+        let memos = trimmedMemos(entry.memos)
 
-            Text("Favorite Emoji:")
-            Text(entry.configuration.favoriteEmoji)
+        VStack(alignment: .leading, spacing: 12) {
+            headerView
+
+            if memos.isEmpty {
+                emptyStateView
+            } else {
+                VStack(spacing: 10) {
+                    ForEach(memos) { memo in
+                        MemoCardView(
+                            memo: memo,
+                            status: statusMap[memo.statusId]
+                        )
+                    }
+                }
+            }
         }
+        .padding(14)
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+
+    private var headerView: some View {
+        HStack {
+            Text("Hand Note")
+                .font(.headline)
+                .foregroundStyle(.primary)
+            Spacer()
+            Image(systemName: "rectangle.grid.1x2.fill")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var emptyStateView: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("メモがありません")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Text("アプリで新しいメモを追加してください")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func trimmedMemos(_ memos: [MemoItem]) -> [MemoItem] {
+        if family == .systemSmall {
+            return Array(memos.prefix(WidgetConstants.maxCardsForSmall))
+        }
+        return memos
+    }
+}
+
+struct MemoCardView: View {
+    let memo: MemoItem
+    let status: StatusItem?
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 10, height: 10)
+                .padding(.top, 6)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(status?.statusNm ?? "未設定")
+                    .font(.caption)
+                    .foregroundStyle(statusColor)
+
+                Text(memo.content)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private var statusColor: Color {
+        Color(hex: status?.statusColor) ?? Color.accentColor
+    }
+}
+
+extension Color {
+    init?(hex: String?) {
+        guard let hex = hex?.trimmingCharacters(in: CharacterSet.alphanumerics.inverted),
+              !hex.isEmpty else {
+            return nil
+        }
+
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+
+        let r, g, b: UInt64
+        switch hex.count {
+        case 6:
+            (r, g, b) = (int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        case 8:
+            (r, g, b) = (int >> 24 & 0xFF, int >> 16 & 0xFF, int >> 8 & 0xFF)
+        default:
+            return nil
+        }
+
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue: Double(b) / 255,
+            opacity: 1.0
+        )
     }
 }
 
@@ -61,28 +232,24 @@ struct MemoHomeWidget: Widget {
     var body: some WidgetConfiguration {
         AppIntentConfiguration(kind: kind, intent: ConfigurationAppIntent.self, provider: Provider()) { entry in
             MemoHomeWidgetEntryView(entry: entry)
-                .containerBackground(.fill.tertiary, for: .widget)
         }
-    }
-}
-
-extension ConfigurationAppIntent {
-    fileprivate static var smiley: ConfigurationAppIntent {
-        let intent = ConfigurationAppIntent()
-        intent.favoriteEmoji = "😀"
-        return intent
-    }
-    
-    fileprivate static var starEyes: ConfigurationAppIntent {
-        let intent = ConfigurationAppIntent()
-        intent.favoriteEmoji = "🤩"
-        return intent
     }
 }
 
 #Preview(as: .systemSmall) {
     MemoHomeWidget()
 } timeline: {
-    SimpleEntry(date: .now, configuration: .smiley)
-    SimpleEntry(date: .now, configuration: .starEyes)
+    MemoHomeWidgetDataProvider.loadEntry(isPreview: true)
+}
+
+#Preview(as: .systemMedium) {
+    MemoHomeWidget()
+} timeline: {
+    MemoHomeWidgetDataProvider.loadEntry(isPreview: true)
+}
+
+#Preview(as: .systemLarge) {
+    MemoHomeWidget()
+} timeline: {
+    MemoHomeWidgetDataProvider.loadEntry(isPreview: true)
 }

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -586,7 +586,7 @@
 					"@executable_path/Frameworks",
 				);
 				NEW_SETTING = "";
-				PRODUCT_BUNDLE_IDENTIFIER = com.ttperry.handnote;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ttperry.handnote.MemoHomeWidgetExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -771,7 +771,7 @@
 					"@executable_path/Frameworks",
 				);
 				NEW_SETTING = "";
-				PRODUCT_BUNDLE_IDENTIFIER = com.ttperry.handnote;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ttperry.handnote.MemoHomeWidgetExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -796,7 +796,7 @@
 					"@executable_path/Frameworks",
 				);
 				NEW_SETTING = "";
-				PRODUCT_BUNDLE_IDENTIFIER = com.ttperry.handnote;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ttperry.handnote.MemoHomeWidgetExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
### Motivation
- Surface the app memo list in the iOS Home widget and render cards similar to Android by adding a UI and data provider.
- Make the WidgetKit extension discoverable on iOS by ensuring the plist contains the correct principal class and the extension uses a distinct bundle identifier.
- Avoid overflow on small widgets by making the UI size-aware and trimming content for `.systemSmall` widgets.
- Provide deterministic previews for development by returning a single timeline entry with policy `.never` and sample data.

### Description
- Implemented widget UI and data layer in `ios/MemoHomeWidget/MemoHomeWidget.swift`, adding `WidgetConstants`, `MemoHomeWidgetDataProvider`, `MemoWidgetEntry`, `MemoItem`, `StatusItem`, `MemoHomeWidgetEntryView`, `MemoCardView`, and a `Color(hex:)` initializer. 
- Load JSON from App Group `UserDefaults(suiteName:)` for keys `memo_list` and `status_list`, include preview sample data, and return a single-entry timeline with `.never` policy. 
- Added `NSExtensionPrincipalClass` to `ios/MemoHomeWidget/Info.plist` to ensure the widget appears in the Add Widgets UI. 
- Updated `ios/Runner.xcodeproj/project.pbxproj` to set the widget extension `PRODUCT_BUNDLE_IDENTIFIER` to `com.ttperry.handnote.MemoHomeWidgetExtension` so it does not conflict with the main app.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69560d05c1f88323b0fb812d54983399)