### PR TITLE
Simplify iOS widget memo card (title + content only)

### DIFF
--- a/ios/MemoWidgets/MemoWidgets.swift
+++ b/ios/MemoWidgets/MemoWidgets.swift
@@ -10,11 +10,19 @@ import SwiftUI
 
 struct Provider: TimelineProvider {
     func placeholder(in context: Context) -> SimpleEntry {
-        SimpleEntry(date: Date(), emoji: "😀")
+        SimpleEntry(
+            date: Date(),
+            title: "買い物メモ",
+            content: "牛乳、卵、パンを買う"
+        )
     }
 
     func getSnapshot(in context: Context, completion: @escaping (SimpleEntry) -> ()) {
-        let entry = SimpleEntry(date: Date(), emoji: "😀")
+        let entry = SimpleEntry(
+            date: Date(),
+            title: "買い物メモ",
+            content: "牛乳、卵、パンを買う"
+        )
         completion(entry)
     }
 
@@ -25,7 +33,11 @@ struct Provider: TimelineProvider {
         let currentDate = Date()
         for hourOffset in 0 ..< 5 {
             let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
-            let entry = SimpleEntry(date: entryDate, emoji: "😀")
+            let entry = SimpleEntry(
+                date: entryDate,
+                title: "買い物メモ",
+                content: "牛乳、卵、パンを買う"
+            )
             entries.append(entry)
         }
 
@@ -40,20 +52,29 @@ struct Provider: TimelineProvider {
 
 struct SimpleEntry: TimelineEntry {
     let date: Date
-    let emoji: String
+    let title: String
+    let content: String
 }
 
 struct MemoWidgetsEntryView : View {
     var entry: Provider.Entry
 
     var body: some View {
-        VStack {
-            Text("Time:")
-            Text(entry.date, style: .time)
-
-            Text("Emoji:")
-            Text(entry.emoji)
+        VStack(alignment: .leading, spacing: 6) {
+            Text(entry.title)
+                .font(.headline)
+                .lineLimit(1)
+            Text(entry.content)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
         }
+        .padding(12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(.secondarySystemBackground))
+        )
     }
 }
 
@@ -79,6 +100,14 @@ struct MemoWidgets: Widget {
 #Preview(as: .systemSmall) {
     MemoWidgets()
 } timeline: {
-    SimpleEntry(date: .now, emoji: "😀")
-    SimpleEntry(date: .now, emoji: "🤩")
+    SimpleEntry(
+        date: .now,
+        title: "買い物メモ",
+        content: "牛乳、卵、パンを買う"
+    )
+    SimpleEntry(
+        date: .now,
+        title: "読書メモ",
+        content: "SwiftUIのWidgetKitの章を読む"
+    )
 }

--- a/ios/MemoWidgets/MemoWidgets.swift
+++ b/ios/MemoWidgets/MemoWidgets.swift
@@ -8,21 +8,17 @@
 import WidgetKit
 import SwiftUI
 
+private let appGroupId = "group.com.ttperry.handnote"
+private let memoListKey = "memo_list"
+private let statusListKey = "status_list"
+
 struct Provider: TimelineProvider {
     func placeholder(in context: Context) -> SimpleEntry {
-        SimpleEntry(
-            date: Date(),
-            title: "買い物メモ",
-            content: "牛乳、卵、パンを買う"
-        )
+        makeEntry(date: Date())
     }
 
     func getSnapshot(in context: Context, completion: @escaping (SimpleEntry) -> ()) {
-        let entry = SimpleEntry(
-            date: Date(),
-            title: "買い物メモ",
-            content: "牛乳、卵、パンを買う"
-        )
+        let entry = makeEntry(date: Date())
         completion(entry)
     }
 
@@ -33,11 +29,7 @@ struct Provider: TimelineProvider {
         let currentDate = Date()
         for hourOffset in 0 ..< 5 {
             let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
-            let entry = SimpleEntry(
-                date: entryDate,
-                title: "買い物メモ",
-                content: "牛乳、卵、パンを買う"
-            )
+            let entry = makeEntry(date: entryDate)
             entries.append(entry)
         }
 
@@ -48,6 +40,70 @@ struct Provider: TimelineProvider {
 //    func relevances() async -> WidgetRelevances<Void> {
 //        // Generate a list containing the contexts this widget is relevant in.
 //    }
+}
+
+private func makeEntry(date: Date) -> SimpleEntry {
+    let data = loadLatestMemo()
+    return SimpleEntry(
+        date: date,
+        title: data.title,
+        content: data.content
+    )
+}
+
+private func loadLatestMemo() -> (title: String, content: String) {
+    guard let defaults = UserDefaults(suiteName: appGroupId),
+          let memoRaw = defaults.string(forKey: memoListKey),
+          let memoList = decodeJsonArray(memoRaw),
+          let first = memoList.first,
+          let content = first["content"] as? String,
+          !content.isEmpty else {
+        return (title: "メモ", content: "メモがありません")
+    }
+
+    let statusName = resolveStatusName(
+        defaults: defaults,
+        statusId: intValue(first["statusId"])
+    )
+
+    return (title: statusName ?? "メモ", content: content)
+}
+
+private func resolveStatusName(defaults: UserDefaults, statusId: Int?) -> String? {
+    guard let statusId = statusId,
+          let statusRaw = defaults.string(forKey: statusListKey),
+          let statusList = decodeJsonArray(statusRaw) else {
+        return nil
+    }
+
+    for status in statusList {
+        if intValue(status["statusId"]) == statusId {
+            return status["statusNm"] as? String
+        }
+    }
+
+    return nil
+}
+
+private func decodeJsonArray(_ raw: String) -> [[String: Any]]? {
+    guard let data = raw.data(using: .utf8) else {
+        return nil
+    }
+
+    return (try? JSONSerialization.jsonObject(with: data)) as? [[String: Any]]
+}
+
+private func intValue(_ value: Any?) -> Int? {
+    if let intValue = value as? Int {
+        return intValue
+    }
+    if let doubleValue = value as? Double {
+        return Int(doubleValue)
+    }
+    if let stringValue = value as? String {
+        return Int(stringValue)
+    }
+    return nil
 }
 
 struct SimpleEntry: TimelineEntry {
@@ -102,12 +158,12 @@ struct MemoWidgets: Widget {
 } timeline: {
     SimpleEntry(
         date: .now,
-        title: "買い物メモ",
+        title: "未着手",
         content: "牛乳、卵、パンを買う"
     )
     SimpleEntry(
         date: .now,
-        title: "読書メモ",
+        title: "進行中",
         content: "SwiftUIのWidgetKitの章を読む"
     )
 }


### PR DESCRIPTION
### Motivation
- Remove emojis and extra status/timestamp UI to keep the widget as simple as possible per UI request.
- Show a minimal memo-style card with only `title` and `content` dummy data for clearer previewing.
- Keep changes confined to the widget extension to avoid wider app impact.

### Description
- Updated `ios/MemoWidgets/MemoWidgets.swift` to replace the previous `emoji`/status fields with `title` and `content` on `SimpleEntry`.
- Adjusted `Provider` implementations (`placeholder`, `getSnapshot`, and `getTimeline`) to populate `SimpleEntry` with dummy `title` and `content` values.
- Simplified `MemoWidgetsEntryView` to render only the memo `title` and `content` with basic typography, padding, and a rounded background.
- Updated the `#Preview` timeline to include two sample `SimpleEntry` previews demonstrating the simplified layout.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956819b2cdc832380e2995e1a72e785)