### PR TITLE
iOS widget: render memo list as card-style entries using App Group data

### DIFF
--- a/ios/MemoWidgets/MemoWidgets.swift
+++ b/ios/MemoWidgets/MemoWidgets.swift
@@ -11,6 +11,7 @@ import SwiftUI
 private let appGroupId = "group.com.ttperry.handnote"
 private let memoListKey = "memo_list"
 private let statusListKey = "status_list"
+private let maxDisplayCount = 4
 
 struct MemoWidgetMemo: Identifiable {
     let id: Int
@@ -102,15 +103,17 @@ struct MemoWidgetsEntryView: View {
     }
 
     var body: some View {
+        let displayedMemos = Array(entry.memos.prefix(maxDisplayCount))
+
         VStack(alignment: .leading, spacing: 12) {
-            ForEach(entry.memos) { memo in
+            ForEach(displayedMemos) { memo in
                 MemoCardView(
                     memo: memo,
                     status: statusMap[memo.statusId]
                 )
             }
 
-            if entry.memos.isEmpty {
+            if displayedMemos.isEmpty {
                 Text("メモがありません")
                     .font(.footnote)
                     .foregroundColor(.secondary)

--- a/ios/MemoWidgets/MemoWidgets.swift
+++ b/ios/MemoWidgets/MemoWidgets.swift
@@ -8,28 +8,44 @@
 import WidgetKit
 import SwiftUI
 
+private let appGroupId = "group.com.ttperry.handnote"
+private let memoListKey = "memo_list"
+private let statusListKey = "status_list"
+
+struct MemoWidgetMemo: Identifiable {
+    let id: Int
+    let content: String
+    let statusId: Int
+}
+
+struct MemoWidgetStatus {
+    let id: Int
+    let name: String
+    let colorHex: String
+}
+
 struct Provider: TimelineProvider {
     func placeholder(in context: Context) -> SimpleEntry {
-        SimpleEntry(date: Date(), emoji: "😀")
+        let sampleStatuses = [
+            MemoWidgetStatus(id: 2, name: "未完了", colorHex: "#4CAF50"),
+            MemoWidgetStatus(id: 3, name: "進行中", colorHex: "#FF9800")
+        ]
+        let sampleMemos = [
+            MemoWidgetMemo(id: 1, content: "買い物リストを更新", statusId: 2),
+            MemoWidgetMemo(id: 2, content: "企画書レビュー", statusId: 3)
+        ]
+        return SimpleEntry(date: Date(), memos: sampleMemos, statuses: sampleStatuses)
     }
 
     func getSnapshot(in context: Context, completion: @escaping (SimpleEntry) -> ()) {
-        let entry = SimpleEntry(date: Date(), emoji: "😀")
+        let entry = loadEntry(date: Date())
         completion(entry)
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
-        var entries: [SimpleEntry] = []
-
-        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
-        let currentDate = Date()
-        for hourOffset in 0 ..< 5 {
-            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
-            let entry = SimpleEntry(date: entryDate, emoji: "😀")
-            entries.append(entry)
-        }
-
-        let timeline = Timeline(entries: entries, policy: .atEnd)
+        let entry = loadEntry(date: Date())
+        let refreshDate = Calendar.current.date(byAdding: .minute, value: 15, to: entry.date) ?? entry.date
+        let timeline = Timeline(entries: [entry], policy: .after(refreshDate))
         completion(timeline)
     }
 
@@ -38,22 +54,102 @@ struct Provider: TimelineProvider {
 //    }
 }
 
-struct SimpleEntry: TimelineEntry {
-    let date: Date
-    let emoji: String
+    private func loadEntry(date: Date) -> SimpleEntry {
+        let defaults = UserDefaults(suiteName: appGroupId)
+        let memoJson = defaults?.string(forKey: memoListKey) ?? "[]"
+        let statusJson = defaults?.string(forKey: statusListKey) ?? "[]"
+
+        let memos = decodeMemos(from: memoJson)
+        let statuses = decodeStatuses(from: statusJson)
+        return SimpleEntry(date: date, memos: memos, statuses: statuses)
+    }
+
+    private func decodeMemos(from json: String) -> [MemoWidgetMemo] {
+        guard let data = json.data(using: .utf8) else { return [] }
+        guard let raw = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else { return [] }
+        return raw.compactMap { item in
+            let memoId = item["memoId"] as? Int ?? item["id"] as? Int ?? -1
+            let content = item["content"] as? String ?? ""
+            let statusId = item["statusId"] as? Int ?? -1
+            guard memoId >= 0 else { return nil }
+            return MemoWidgetMemo(id: memoId, content: content, statusId: statusId)
+        }
+    }
+
+    private func decodeStatuses(from json: String) -> [MemoWidgetStatus] {
+        guard let data = json.data(using: .utf8) else { return [] }
+        guard let raw = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else { return [] }
+        return raw.compactMap { item in
+            guard let statusId = item["statusId"] as? Int else { return nil }
+            let statusNm = item["statusNm"] as? String ?? "未完了"
+            let statusColor = item["statusColor"] as? String ?? "#4CAF50"
+            return MemoWidgetStatus(id: statusId, name: statusNm, colorHex: statusColor)
+        }
+    }
 }
 
-struct MemoWidgetsEntryView : View {
+struct SimpleEntry: TimelineEntry {
+    let date: Date
+    let memos: [MemoWidgetMemo]
+    let statuses: [MemoWidgetStatus]
+}
+
+struct MemoWidgetsEntryView: View {
     var entry: Provider.Entry
 
-    var body: some View {
-        VStack {
-            Text("Time:")
-            Text(entry.date, style: .time)
+    private var statusMap: [Int: MemoWidgetStatus] {
+        Dictionary(uniqueKeysWithValues: entry.statuses.map { ($0.id, $0) })
+    }
 
-            Text("Emoji:")
-            Text(entry.emoji)
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ForEach(entry.memos) { memo in
+                MemoCardView(
+                    memo: memo,
+                    status: statusMap[memo.statusId]
+                )
+            }
+
+            if entry.memos.isEmpty {
+                Text("メモがありません")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+    }
+}
+
+struct MemoCardView: View {
+    let memo: MemoWidgetMemo
+    let status: MemoWidgetStatus?
+
+    var body: some View {
+        let statusColor = Color(hex: status?.colorHex ?? "#4CAF50")
+        let statusName = status?.name ?? "未完了"
+
+        HStack(spacing: 12) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 12, height: 12)
+
+            Text(memo.content)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundColor(.primary)
+                .lineLimit(2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text(statusName)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(statusColor)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 }
 
@@ -71,14 +167,50 @@ struct MemoWidgets: Widget {
                     .background()
             }
         }
-        .configurationDisplayName("My Widget")
-        .description("This is an example widget.")
+        .configurationDisplayName("メモ一覧")
+        .description("メモの件数に応じてカード表示します。")
     }
 }
 
 #Preview(as: .systemSmall) {
     MemoWidgets()
 } timeline: {
-    SimpleEntry(date: .now, emoji: "😀")
-    SimpleEntry(date: .now, emoji: "🤩")
+    SimpleEntry(
+        date: .now,
+        memos: [
+            MemoWidgetMemo(id: 1, content: "今日のタスク整理", statusId: 2),
+            MemoWidgetMemo(id: 2, content: "会議メモ整理", statusId: 3)
+        ],
+        statuses: [
+            MemoWidgetStatus(id: 2, name: "未完了", colorHex: "#4CAF50"),
+            MemoWidgetStatus(id: 3, name: "進行中", colorHex: "#FF9800")
+        ]
+    )
+}
+
+private extension Color {
+    init(hex: String) {
+        let cleaned = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: cleaned).scanHexInt64(&int)
+
+        let r, g, b: UInt64
+        switch cleaned.count {
+        case 6:
+            (r, g, b) = ((int >> 16) & 0xFF, (int >> 8) & 0xFF, int & 0xFF)
+        case 3:
+            (r, g, b) = ((int >> 8) & 0xF, (int >> 4) & 0xF, int & 0xF)
+            (r, g, b) = (r * 17, g * 17, b * 17)
+        default:
+            (r, g, b) = (76, 175, 80)
+        }
+
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue: Double(b) / 255,
+            opacity: 1
+        )
+    }
 }


### PR DESCRIPTION
### Motivation
- Provide an iOS widget that mirrors the Android card-style memo list and shows multiple memo items according to the memo count.
- Read memo/status JSON saved by the app into the shared App Group so the widget reflects current app data.
- Improve widget preview and configuration copy to better describe memo-list behavior.

### Description
- Updated `ios/MemoWidgets/MemoWidgets.swift` to read from `UserDefaults(suiteName:)` using the app group `group.com.ttperry.handnote` and keys `memo_list` / `status_list`.
- Added DTO-like types `MemoWidgetMemo` and `MemoWidgetStatus`, JSON decoding helpers, and a `loadEntry` function to build `SimpleEntry` with `memos` and `statuses`.
- Replaced placeholder/preview content and timeline policy to produce a single refreshed entry and implemented SwiftUI views `MemoWidgetsEntryView` and `MemoCardView` to render cards (status circle, content, status name) and a `Color` hex initializer.
- Updated widget display name and description to Japanese strings and adjusted preview timeline sample data.

### Testing
- No automated tests were run for this change.
- No CI or build verification was executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69568af8122083238a36f187f617f72d)