### PR TITLE
Split widget view into separate files and move Color helper

### DIFF
--- a/ios/MemoWidgets/MemoCardView.swift
+++ b/ios/MemoWidgets/MemoCardView.swift
@@ -1,1 +1,59 @@
-MemoCardView.swift
+import SwiftUI
+
+struct MemoCardView: View {
+    let memo: MemoWidgetMemo
+    let status: MemoWidgetStatus?
+
+    var body: some View {
+        let statusColor = Color(hex: status?.colorHex ?? "#4CAF50")
+        let statusName = status?.name ?? "未完了"
+
+        HStack(spacing: 8) {
+            Circle()
+                .fill(statusColor)
+                .frame(width: 10, height: 10)
+
+            Text(memo.content)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(.primary)
+                .lineLimit(1)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text(statusName)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(statusColor)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+}
+
+private extension Color {
+    init(hex: String) {
+        let cleaned = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: cleaned).scanHexInt64(&int)
+
+        var r, g, b: UInt64
+        switch cleaned.count {
+        case 6:
+            (r, g, b) = ((int >> 16) & 0xFF, (int >> 8) & 0xFF, int & 0xFF)
+        case 3:
+            (r, g, b) = ((int >> 8) & 0xF, (int >> 4) & 0xF, int & 0xF)
+            (r, g, b) = (r * 17, g * 17, b * 17)
+        default:
+            (r, g, b) = (76, 175, 80)
+        }
+
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue: Double(b) / 255,
+            opacity: 1
+        )
+    }
+}

--- a/ios/MemoWidgets/MemoWidgets.swift
+++ b/ios/MemoWidgets/MemoWidgets.swift
@@ -53,7 +53,6 @@ struct Provider: TimelineProvider {
 //    func relevances() async -> WidgetRelevances<Void> {
 //        // Generate a list containing the contexts this widget is relevant in.
 //    }
-}
 
     private func loadEntry(date: Date) -> SimpleEntry {
         let defaults = UserDefaults(suiteName: appGroupId)
@@ -97,72 +96,12 @@ struct Provider: TimelineProvider {
             return MemoWidgetStatus(id: statusId, name: statusNm, colorHex: statusColor)
         }
     }
+}
 
 struct SimpleEntry: TimelineEntry {
     let date: Date
     let memos: [MemoWidgetMemo]
     let statuses: [MemoWidgetStatus]
-}
-
-struct MemoWidgetsEntryView: View {
-    var entry: Provider.Entry
-
-    private var statusMap: [Int: MemoWidgetStatus] {
-        Dictionary(uniqueKeysWithValues: entry.statuses.map { ($0.id, $0) })
-    }
-
-    var body: some View {
-        let displayedMemos = Array(entry.memos.prefix(maxDisplayCount))
-
-        VStack(alignment: .leading, spacing: 6) {
-            ForEach(displayedMemos) { memo in
-                MemoCardView(
-                    memo: memo,
-                    status: statusMap[memo.statusId]
-                )
-            }
-
-            if displayedMemos.isEmpty {
-                Text("メモがありません")
-                    .font(.footnote)
-                    .foregroundColor(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .center)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(12)
-    }
-}
-
-struct MemoCardView: View {
-    let memo: MemoWidgetMemo
-    let status: MemoWidgetStatus?
-
-    var body: some View {
-        let statusColor = Color(hex: status?.colorHex ?? "#4CAF50")
-        let statusName = status?.name ?? "未完了"
-
-        HStack(spacing: 8) {
-            Circle()
-                .fill(statusColor)
-                .frame(width: 10, height: 10)
-
-            Text(memo.content)
-                .font(.system(size: 13, weight: .medium))
-                .foregroundColor(.primary)
-                .lineLimit(1)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            Text(statusName)
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundColor(statusColor)
-                .lineLimit(1)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
-        .background(Color(.systemBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-    }
 }
 
 struct MemoWidgets: Widget {
@@ -198,31 +137,4 @@ struct MemoWidgets: Widget {
             MemoWidgetStatus(id: 3, name: "進行中", colorHex: "#FF9800")
         ]
     )
-}
-
-private extension Color {
-    init(hex: String) {
-        let cleaned = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
-        var int: UInt64 = 0
-        Scanner(string: cleaned).scanHexInt64(&int)
-
-        var r, g, b: UInt64
-        switch cleaned.count {
-        case 6:
-            (r, g, b) = ((int >> 16) & 0xFF, (int >> 8) & 0xFF, int & 0xFF)
-        case 3:
-            (r, g, b) = ((int >> 8) & 0xF, (int >> 4) & 0xF, int & 0xF)
-            (r, g, b) = (r * 17, g * 17, b * 17)
-        default:
-            (r, g, b) = (76, 175, 80)
-        }
-
-        self.init(
-            .sRGB,
-            red: Double(r) / 255,
-            green: Double(g) / 255,
-            blue: Double(b) / 255,
-            opacity: 1
-        )
-    }
 }

--- a/ios/MemoWidgets/MemoWidgetsEntryView.swift
+++ b/ios/MemoWidgets/MemoWidgetsEntryView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct MemoWidgetsEntryView: View {
+    var entry: Provider.Entry
+
+    private var statusMap: [Int: MemoWidgetStatus] {
+        Dictionary(uniqueKeysWithValues: entry.statuses.map { ($0.id, $0) })
+    }
+
+    var body: some View {
+        let displayedMemos = Array(entry.memos.prefix(maxDisplayCount))
+
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach(displayedMemos) { memo in
+                MemoCardView(
+                    memo: memo,
+                    status: statusMap[memo.statusId]
+                )
+            }
+
+            if displayedMemos.isEmpty {
+                Text("メモがありません")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+    }
+}


### PR DESCRIPTION
### Motivation
- The widget Swift file contained multiple view implementations and stray placeholder content which caused poor file organization and potential compile issues.
- Separating views into dedicated files improves clarity and makes it easier to maintain each component independently.
- The `Color(hex:)` helper needed to remain available to the UI after splitting the view code.

### Description
- Moved `MemoWidgetsEntryView` into `ios/MemoWidgets/MemoWidgetsEntryView.swift` as a standalone `View` implementation.
- Moved `MemoCardView` into `ios/MemoWidgets/MemoCardView.swift` and added the `private extension Color { init(hex:) }` helper there.
- Removed the duplicate view implementations and stray placeholder text from `ios/MemoWidgets/MemoWidgets.swift` so it only contains widget/provider logic and previews.
- Updated references so `MemoWidgets` now uses the extracted `MemoWidgetsEntryView` and `MemoCardView` components.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956b72e0c188323901131ceafc7384c)