### PR TITLE
Add category picker sheet to CreateMemoBottomSheet

### DIFF
--- a/lib/core/widgets/create_memo_bottom_sheet.dart
+++ b/lib/core/widgets/create_memo_bottom_sheet.dart
@@ -12,6 +12,14 @@ class CreateMemoBottomSheet extends StatefulWidget {
 class _CreateMemoBottomSheetState extends State<CreateMemoBottomSheet> {
   final TextEditingController _memoController = TextEditingController();
   bool _repeatEnabled = false;
+  final List<_CategoryItem> _categories = const [
+    _CategoryItem(name: 'Reminders', color: Color(0xFFFFA032)),
+    _CategoryItem(name: 'Work', color: Color(0xFF3B82F6)),
+    _CategoryItem(name: 'Personal', color: Color(0xFF10B981)),
+    _CategoryItem(name: 'Ideas', color: Color(0xFF8B5CF6)),
+    _CategoryItem(name: 'Archive', color: Color(0xFF9CA3AF)),
+  ];
+  late _CategoryItem _selectedCategory = _categories.first;
 
   @override
   Widget build(BuildContext context) {
@@ -49,7 +57,10 @@ class _CreateMemoBottomSheetState extends State<CreateMemoBottomSheet> {
 
               const SizedBox(height: 12),
 
-              const _ListSelectRow(),
+              _ListSelectRow(
+                category: _selectedCategory,
+                onTap: _showCategorySheet,
+              ),
 
               const SizedBox(height: 24),
             ],
@@ -62,6 +73,45 @@ class _CreateMemoBottomSheetState extends State<CreateMemoBottomSheet> {
   void _onAdd() {
     // TODO: ViewModel / Repository に委譲
     Navigator.pop(context);
+  }
+
+  Future<void> _showCategorySheet() async {
+    final selected = await showGeneralDialog<_CategoryItem>(
+      context: context,
+      barrierLabel: 'Category',
+      barrierDismissible: true,
+      barrierColor: Colors.black54,
+      transitionDuration: const Duration(milliseconds: 240),
+      pageBuilder: (context, animation, secondaryAnimation) {
+        return Align(
+          alignment: Alignment.centerRight,
+          child: Material(
+            color: Colors.white,
+            child: SafeArea(
+              left: false,
+              child: SizedBox(
+                width: MediaQuery.of(context).size.width * 0.78,
+                child: _CategorySelectSheet(
+                  categories: _categories,
+                  selected: _selectedCategory,
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+      transitionBuilder: (context, animation, secondaryAnimation, child) {
+        final offsetAnimation = Tween<Offset>(
+          begin: const Offset(1, 0),
+          end: Offset.zero,
+        ).animate(CurvedAnimation(parent: animation, curve: Curves.easeOut));
+        return SlideTransition(position: offsetAnimation, child: child);
+      },
+    );
+
+    if (selected != null && selected != _selectedCategory) {
+      setState(() => _selectedCategory = selected);
+    }
   }
 }
 
@@ -182,26 +232,159 @@ class _RepeatRow extends StatelessWidget {
 }
 
 class _ListSelectRow extends StatelessWidget {
-  const _ListSelectRow();
+  final _CategoryItem category;
+  final VoidCallback onTap;
+
+  const _ListSelectRow({
+    required this.category,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
     return _SettingRow(
       title: 'List',
+      onTap: onTap,
       trailing: Row(
-        children: const [
-          CircleAvatar(radius: 4, backgroundColor: Color(0xFFFFA032)),
-          SizedBox(width: 6),
+        children: [
+          CircleAvatar(radius: 4, backgroundColor: category.color),
+          const SizedBox(width: 6),
           Text(
-            'Reminders',
-            style: TextStyle(color: Color(0xFF8E8E92)),
+            category.name,
+            style: const TextStyle(color: Color(0xFF8E8E92)),
           ),
-          SizedBox(width: 6),
-          Icon(Icons.chevron_right, color: Color(0xFFB6B6B9)),
+          const SizedBox(width: 6),
+          const Icon(Icons.chevron_right, color: Color(0xFFB6B6B9)),
         ],
       ),
     );
   }
+}
+
+class _CategorySelectSheet extends StatelessWidget {
+  final List<_CategoryItem> categories;
+  final _CategoryItem selected;
+
+  const _CategorySelectSheet({
+    required this.categories,
+    required this.selected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          height: 56,
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          decoration: const BoxDecoration(
+            color: Color(0xFFE6E5EF),
+          ),
+          child: Row(
+            children: [
+              CupertinoButton(
+                padding: EdgeInsets.zero,
+                onPressed: () => Navigator.pop(context),
+                child: const Text(
+                  'Back',
+                  style: TextStyle(
+                    color: Color(0xFF0C79FE),
+                    fontSize: 17,
+                  ),
+                ),
+              ),
+              const Expanded(
+                child: Text(
+                  'カテゴリ',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 56),
+            ],
+          ),
+        ),
+        Flexible(
+          child: ListView.separated(
+            shrinkWrap: true,
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            itemCount: categories.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 8),
+            itemBuilder: (context, index) {
+              final category = categories[index];
+              return _CategoryListTile(
+                category: category,
+                isSelected: category == selected,
+                onTap: () => Navigator.pop(context, category),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CategoryListTile extends StatelessWidget {
+  final _CategoryItem category;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _CategoryListTile({
+    required this.category,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Material(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
+            child: Row(
+              children: [
+                CircleAvatar(radius: 6, backgroundColor: category.color),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    category.name,
+                    style: const TextStyle(fontSize: 16),
+                  ),
+                ),
+                if (isSelected)
+                  const Icon(
+                    Icons.check,
+                    color: Color(0xFF0C79FE),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+@immutable
+class _CategoryItem {
+  final String name;
+  final Color color;
+
+  const _CategoryItem({
+    required this.name,
+    required this.color,
+  });
 }
 
 
@@ -209,16 +392,18 @@ class _SettingRow extends StatelessWidget {
   final String title;
   final Widget trailing;
   final Color? iconColor;
+  final VoidCallback? onTap;
 
   const _SettingRow({
     required this.title,
     required this.trailing,
     this.iconColor,
+    this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    final content = Container(
       margin: const EdgeInsets.symmetric(horizontal: 16),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
       decoration: BoxDecoration(
@@ -246,6 +431,19 @@ class _SettingRow extends StatelessWidget {
           ),
           trailing,
         ],
+      ),
+    );
+
+    if (onTap == null) {
+      return content;
+    }
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onTap,
+        child: content,
       ),
     );
   }


### PR DESCRIPTION
### Motivation
- Enable selecting a category from the `CreateMemoBottomSheet` so the List row reflects the chosen category name and color.
- Provide a secondary sheet that slides in from the right to display all registered categories for selection. 
- Keep category data simple and in-memory for initial UI behavior and iterative development. 

### Description
- Added an immutable `_CategoryItem` model and an in-memory `List<_CategoryItem>` plus `_selectedCategory` state in `CreateMemoBottomSheet`.
- Implemented `_showCategorySheet` using `showGeneralDialog` with a slide-from-right transition to present a new `_CategorySelectSheet` and return the selected category. 
- Made the list row tappable by updating `_ListSelectRow` to accept `category` and `onTap`, and updated `_SettingRow` to accept `onTap` and render an `InkWell` when provided. 
- Added `_CategorySelectSheet` and `_CategoryListTile` widgets to list categories and allow selection, showing a check for the current selection. 

### Testing
- No automated tests were run for this change.
- The patch was compiled locally as part of the commit but no UI test or integration test was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a1e7c7b788323bd26563549ccb7ec)