### PR TITLE
Switch CreateMemoBottomSheet between memo and category views

### DIFF
--- a/lib/core/widgets/create_memo_bottom_sheet.dart
+++ b/lib/core/widgets/create_memo_bottom_sheet.dart
@@ -12,6 +12,15 @@ class CreateMemoBottomSheet extends StatefulWidget {
 class _CreateMemoBottomSheetState extends State<CreateMemoBottomSheet> {
   final TextEditingController _memoController = TextEditingController();
   bool _repeatEnabled = false;
+  _SheetMode _sheetMode = _SheetMode.memo;
+  final List<_CategoryItem> _categories = const [
+    _CategoryItem(name: 'Reminders', color: Color(0xFFFFA032)),
+    _CategoryItem(name: 'Work', color: Color(0xFF3B82F6)),
+    _CategoryItem(name: 'Personal', color: Color(0xFF10B981)),
+    _CategoryItem(name: 'Ideas', color: Color(0xFF8B5CF6)),
+    _CategoryItem(name: 'Archive', color: Color(0xFF9CA3AF)),
+  ];
+  late _CategoryItem _selectedCategory = _categories.first;
 
   @override
   Widget build(BuildContext context) {
@@ -31,27 +40,41 @@ class _CreateMemoBottomSheetState extends State<CreateMemoBottomSheet> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              _Header(
-                onCancel: () => Navigator.pop(context),
-                onAdd: _memoController.text.isEmpty ? null : _onAdd,
+              AnimatedSwitcher(
+                duration: const Duration(milliseconds: 220),
+                switchInCurve: Curves.easeOut,
+                switchOutCurve: Curves.easeIn,
+                transitionBuilder: (child, animation) {
+                  final offsetAnimation = Tween<Offset>(
+                    begin: const Offset(0.1, 0),
+                    end: Offset.zero,
+                  ).animate(animation);
+                  return SlideTransition(
+                    position: offsetAnimation,
+                    child: FadeTransition(opacity: animation, child: child),
+                  );
+                },
+                child: _sheetMode == _SheetMode.memo
+                    ? _MemoSheetContent(
+                        key: const ValueKey('memo'),
+                        memoController: _memoController,
+                        repeatEnabled: _repeatEnabled,
+                        onRepeatChanged: (v) =>
+                            setState(() => _repeatEnabled = v),
+                        category: _selectedCategory,
+                        onCategoryTap: _showCategorySheet,
+                        onCancel: () => Navigator.pop(context),
+                        onAdd:
+                            _memoController.text.isEmpty ? null : _onAdd,
+                      )
+                    : _CategorySheetContent(
+                        key: const ValueKey('category'),
+                        categories: _categories,
+                        selectedCategory: _selectedCategory,
+                        onBack: _showMemoSheet,
+                        onSelect: _selectCategory,
+                      ),
               ),
-
-              const SizedBox(height: 12),
-
-              _MemoInputCard(controller: _memoController),
-
-              const SizedBox(height: 12),
-
-              _RepeatRow(
-                value: _repeatEnabled,
-                onChanged: (v) => setState(() => _repeatEnabled = v),
-              ),
-
-              const SizedBox(height: 12),
-
-              const _ListSelectRow(),
-
-              const SizedBox(height: 24),
             ],
           ),
         ),
@@ -62,6 +85,152 @@ class _CreateMemoBottomSheetState extends State<CreateMemoBottomSheet> {
   void _onAdd() {
     // TODO: ViewModel / Repository に委譲
     Navigator.pop(context);
+  }
+
+  void _showCategorySheet() {
+    setState(() => _sheetMode = _SheetMode.category);
+  }
+
+  void _showMemoSheet() {
+    setState(() => _sheetMode = _SheetMode.memo);
+  }
+
+  void _selectCategory(_CategoryItem category) {
+    setState(() {
+      _selectedCategory = category;
+      _sheetMode = _SheetMode.memo;
+    });
+  }
+}
+
+class _MemoSheetContent extends StatelessWidget {
+  final TextEditingController memoController;
+  final bool repeatEnabled;
+  final ValueChanged<bool> onRepeatChanged;
+  final _CategoryItem category;
+  final VoidCallback onCategoryTap;
+  final VoidCallback onCancel;
+  final VoidCallback? onAdd;
+
+  const _MemoSheetContent({
+    super.key,
+    required this.memoController,
+    required this.repeatEnabled,
+    required this.onRepeatChanged,
+    required this.category,
+    required this.onCategoryTap,
+    required this.onCancel,
+    required this.onAdd,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _Header(
+          onCancel: onCancel,
+          onAdd: onAdd,
+        ),
+        const SizedBox(height: 12),
+        _MemoInputCard(controller: memoController),
+        const SizedBox(height: 12),
+        _RepeatRow(
+          value: repeatEnabled,
+          onChanged: onRepeatChanged,
+        ),
+        const SizedBox(height: 12),
+        _ListSelectRow(
+          category: category,
+          onTap: onCategoryTap,
+        ),
+        const SizedBox(height: 24),
+      ],
+    );
+  }
+}
+
+class _CategorySheetContent extends StatelessWidget {
+  final List<_CategoryItem> categories;
+  final _CategoryItem selectedCategory;
+  final VoidCallback onBack;
+  final ValueChanged<_CategoryItem> onSelect;
+
+  const _CategorySheetContent({
+    super.key,
+    required this.categories,
+    required this.selectedCategory,
+    required this.onBack,
+    required this.onSelect,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _CategoryHeader(onBack: onBack),
+        Flexible(
+          child: ListView.separated(
+            shrinkWrap: true,
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            itemCount: categories.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 8),
+            itemBuilder: (context, index) {
+              final category = categories[index];
+              return _CategoryListTile(
+                category: category,
+                isSelected: category == selectedCategory,
+                onTap: () => onSelect(category),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CategoryHeader extends StatelessWidget {
+  final VoidCallback onBack;
+
+  const _CategoryHeader({required this.onBack});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 56,
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      decoration: const BoxDecoration(
+        color: Color(0xFFE6E5EF),
+      ),
+      child: Row(
+        children: [
+          CupertinoButton(
+            padding: EdgeInsets.zero,
+            onPressed: onBack,
+            child: const Text(
+              'Back',
+              style: TextStyle(
+                color: Color(0xFF0C79FE),
+                fontSize: 17,
+              ),
+            ),
+          ),
+          const Expanded(
+            child: Text(
+              'カテゴリ',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          const SizedBox(width: 56),
+        ],
+      ),
+    );
   }
 }
 
@@ -182,26 +351,91 @@ class _RepeatRow extends StatelessWidget {
 }
 
 class _ListSelectRow extends StatelessWidget {
-  const _ListSelectRow();
+  final _CategoryItem category;
+  final VoidCallback onTap;
+
+  const _ListSelectRow({
+    required this.category,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
     return _SettingRow(
       title: 'List',
+      onTap: onTap,
       trailing: Row(
-        children: const [
-          CircleAvatar(radius: 4, backgroundColor: Color(0xFFFFA032)),
-          SizedBox(width: 6),
+        children: [
+          CircleAvatar(radius: 4, backgroundColor: category.color),
+          const SizedBox(width: 6),
           Text(
-            'Reminders',
-            style: TextStyle(color: Color(0xFF8E8E92)),
+            category.name,
+            style: const TextStyle(color: Color(0xFF8E8E92)),
           ),
-          SizedBox(width: 6),
-          Icon(Icons.chevron_right, color: Color(0xFFB6B6B9)),
+          const SizedBox(width: 6),
+          const Icon(Icons.chevron_right, color: Color(0xFFB6B6B9)),
         ],
       ),
     );
   }
+}
+
+class _CategoryListTile extends StatelessWidget {
+  final _CategoryItem category;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _CategoryListTile({
+    required this.category,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Material(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
+            child: Row(
+              children: [
+                CircleAvatar(radius: 6, backgroundColor: category.color),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    category.name,
+                    style: const TextStyle(fontSize: 16),
+                  ),
+                ),
+                if (isSelected)
+                  const Icon(
+                    Icons.check,
+                    color: Color(0xFF0C79FE),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+@immutable
+class _CategoryItem {
+  final String name;
+  final Color color;
+
+  const _CategoryItem({
+    required this.name,
+    required this.color,
+  });
 }
 
 
@@ -209,16 +443,18 @@ class _SettingRow extends StatelessWidget {
   final String title;
   final Widget trailing;
   final Color? iconColor;
+  final VoidCallback? onTap;
 
   const _SettingRow({
     required this.title,
     required this.trailing,
     this.iconColor,
+    this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    final content = Container(
       margin: const EdgeInsets.symmetric(horizontal: 16),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
       decoration: BoxDecoration(
@@ -248,5 +484,20 @@ class _SettingRow extends StatelessWidget {
         ],
       ),
     );
+
+    if (onTap == null) {
+      return content;
+    }
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onTap,
+        child: content,
+      ),
+    );
   }
 }
+
+enum _SheetMode { memo, category }


### PR DESCRIPTION
### Motivation
- Present the category list in the same bottom sheet area instead of opening a separate right-side dialog so users can switch views in-place.
- Allow selecting a category and immediately reflecting it in the memo row without leaving the sheet area.
- Provide a simple in-memory set of categories for initial UI behavior and iteration.

### Description
- Added an internal `_SheetMode` enum and `_sheetMode` state, plus an in-memory `_categories` list and `_selectedCategory` to `CreateMemoBottomSheet` to track view and selection state.
- Replaced the previous `showGeneralDialog` flow with an `AnimatedSwitcher` that toggles between ` _MemoSheetContent` and `_CategorySheetContent` and provides animated transitions.
- Introduced ` _MemoSheetContent`, `_CategorySheetContent`, `_CategoryHeader`, `_CategoryListTile`, and an immutable `_CategoryItem` model, and wired selection handlers ` _showCategorySheet`, `_showMemoSheet`, and `_selectCategory` to switch modes and update selection.
- Updated `_ListSelectRow` and `_SettingRow` to accept `category`/`onTap` and render the chosen category color/name and make the row tappable.

### Testing
- No automated tests were run for this change.
- Manual app execution was not performed as part of this automated change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a1e7c7b788323bd26563549ccb7ec)