### PR TITLE
Round CreateMemoBottomSheet corners and top-align content

### DIFF
--- a/lib/core/widgets/create_memo_bottom_sheet.dart
+++ b/lib/core/widgets/create_memo_bottom_sheet.dart
@@ -12,47 +12,94 @@ class CreateMemoBottomSheet extends StatefulWidget {
 class _CreateMemoBottomSheetState extends State<CreateMemoBottomSheet> {
   final TextEditingController _memoController = TextEditingController();
   bool _repeatEnabled = false;
+  _SheetMode _sheetMode = _SheetMode.memo;
+  final List<_CategoryItem> _categories = const [
+    _CategoryItem(name: 'Reminders', color: Color(0xFFFFA032)),
+    _CategoryItem(name: 'Work', color: Color(0xFF3B82F6)),
+    _CategoryItem(name: 'Personal', color: Color(0xFF10B981)),
+    _CategoryItem(name: 'Ideas', color: Color(0xFF8B5CF6)),
+    _CategoryItem(name: 'Archive', color: Color(0xFF9CA3AF)),
+  ];
+  late _CategoryItem _selectedCategory = _categories.first;
 
   @override
   Widget build(BuildContext context) {
     final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+    final sheetHeight = MediaQuery.of(context).size.height * 0.62;
 
     return SafeArea(
       top: false,
       child: Padding(
         padding: EdgeInsets.only(bottom: bottomInset),
-        child: Container(
-          decoration: const BoxDecoration(
-            color: Color(0xFFF2F2F6),
-            borderRadius: BorderRadius.vertical(
-              top: Radius.circular(20),
-            ),
+        child: ClipRRect(
+          borderRadius: const BorderRadius.vertical(
+            top: Radius.circular(20),
           ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              _Header(
-                onCancel: () => Navigator.pop(context),
-                onAdd: _memoController.text.isEmpty ? null : _onAdd,
+          child: Container(
+            decoration: const BoxDecoration(
+              color: Color(0xFFF2F2F6),
+            ),
+            child: SizedBox(
+              height: sheetHeight,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [
+                  _SheetHeader(
+                    leadingLabel:
+                        _sheetMode == _SheetMode.memo ? 'Cancel' : 'Back',
+                    onLeadingTap: _sheetMode == _SheetMode.memo
+                        ? () => Navigator.pop(context)
+                        : _showMemoSheet,
+                    title:
+                        _sheetMode == _SheetMode.memo ? '新規メモ' : 'カテゴリ',
+                    trailingLabel: _sheetMode == _SheetMode.memo ? 'Add' : null,
+                    onTrailingTap: _sheetMode == _SheetMode.memo &&
+                            _memoController.text.isNotEmpty
+                        ? _onAdd
+                        : null,
+                  ),
+                  Expanded(
+                    child: Align(
+                      alignment: Alignment.topCenter,
+                      child: AnimatedSwitcher(
+                        duration: const Duration(milliseconds: 220),
+                        switchInCurve: Curves.easeOut,
+                        switchOutCurve: Curves.easeIn,
+                        transitionBuilder: (child, animation) {
+                          final offsetAnimation = Tween<Offset>(
+                            begin: const Offset(0.1, 0),
+                            end: Offset.zero,
+                          ).animate(animation);
+                          return SlideTransition(
+                            position: offsetAnimation,
+                            child: FadeTransition(
+                              opacity: animation,
+                              child: child,
+                            ),
+                          );
+                        },
+                        child: _sheetMode == _SheetMode.memo
+                            ? _MemoSheetContent(
+                                key: const ValueKey('memo'),
+                                memoController: _memoController,
+                                repeatEnabled: _repeatEnabled,
+                                onRepeatChanged: (v) =>
+                                    setState(() => _repeatEnabled = v),
+                                category: _selectedCategory,
+                                onCategoryTap: _showCategorySheet,
+                              )
+                            : _CategorySheetContent(
+                                key: const ValueKey('category'),
+                                categories: _categories,
+                                selectedCategory: _selectedCategory,
+                                onSelect: _selectCategory,
+                              ),
+                      ),
+                    ),
+                  ),
+                ],
               ),
-
-              const SizedBox(height: 12),
-
-              _MemoInputCard(controller: _memoController),
-
-              const SizedBox(height: 12),
-
-              _RepeatRow(
-                value: _repeatEnabled,
-                onChanged: (v) => setState(() => _repeatEnabled = v),
-              ),
-
-              const SizedBox(height: 12),
-
-              const _ListSelectRow(),
-
-              const SizedBox(height: 24),
-            ],
+            ),
           ),
         ),
       ),
@@ -63,16 +110,111 @@ class _CreateMemoBottomSheetState extends State<CreateMemoBottomSheet> {
     // TODO: ViewModel / Repository に委譲
     Navigator.pop(context);
   }
+
+  void _showCategorySheet() {
+    setState(() => _sheetMode = _SheetMode.category);
+  }
+
+  void _showMemoSheet() {
+    setState(() => _sheetMode = _SheetMode.memo);
+  }
+
+  void _selectCategory(_CategoryItem category) {
+    setState(() {
+      _selectedCategory = category;
+      _sheetMode = _SheetMode.memo;
+    });
+  }
 }
 
+class _MemoSheetContent extends StatelessWidget {
+  final TextEditingController memoController;
+  final bool repeatEnabled;
+  final ValueChanged<bool> onRepeatChanged;
+  final _CategoryItem category;
+  final VoidCallback onCategoryTap;
 
-class _Header extends StatelessWidget {
-  final VoidCallback onCancel;
-  final VoidCallback? onAdd;
+  const _MemoSheetContent({
+    super.key,
+    required this.memoController,
+    required this.repeatEnabled,
+    required this.onRepeatChanged,
+    required this.category,
+    required this.onCategoryTap,
+  });
 
-  const _Header({
-    required this.onCancel,
-    required this.onAdd,
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.only(top: 12, bottom: 24),
+      child: Column(
+        children: [
+          _MemoInputCard(controller: memoController),
+          const SizedBox(height: 12),
+          _RepeatRow(
+            value: repeatEnabled,
+            onChanged: onRepeatChanged,
+          ),
+          const SizedBox(height: 12),
+          _ListSelectRow(
+            category: category,
+            onTap: onCategoryTap,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CategorySheetContent extends StatelessWidget {
+  final List<_CategoryItem> categories;
+  final _CategoryItem selectedCategory;
+  final ValueChanged<_CategoryItem> onSelect;
+
+  const _CategorySheetContent({
+    super.key,
+    required this.categories,
+    required this.selectedCategory,
+    required this.onSelect,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Expanded(
+          child: ListView.separated(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            itemCount: categories.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 8),
+            itemBuilder: (context, index) {
+              final category = categories[index];
+              return _CategoryListTile(
+                category: category,
+                isSelected: category == selectedCategory,
+                onTap: () => onSelect(category),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SheetHeader extends StatelessWidget {
+  final String leadingLabel;
+  final VoidCallback onLeadingTap;
+  final String title;
+  final String? trailingLabel;
+  final VoidCallback? onTrailingTap;
+
+  const _SheetHeader({
+    required this.leadingLabel,
+    required this.onLeadingTap,
+    required this.title,
+    required this.trailingLabel,
+    required this.onTrailingTap,
   });
 
   @override
@@ -83,46 +225,50 @@ class _Header extends StatelessWidget {
       decoration: const BoxDecoration(
         color: Color(0xFFE6E5EF),
       ),
-      child: Stack(
-        alignment: Alignment.center,
+      child: Row(
         children: [
-          Align(
-            alignment: Alignment.centerLeft,
-            child: CupertinoButton(
-              padding: EdgeInsets.zero,
-              onPressed: onCancel,
-              child: const Text(
-                'Cancel',
-                style: TextStyle(
-                  color: Color(0xFF0C79FE),
-                  fontSize: 17,
-                ),
+          CupertinoButton(
+            padding: EdgeInsets.zero,
+            onPressed: onLeadingTap,
+            child: Text(
+              leadingLabel,
+              style: TextStyle(
+                color: Color(0xFF0C79FE),
+                fontSize: 17,
               ),
             ),
           ),
-          const Text(
-            '新規メモ',
-            style: TextStyle(
-              fontSize: 16,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-          Align(
-            alignment: Alignment.centerRight,
-            child: CupertinoButton(
-              padding: EdgeInsets.zero,
-              onPressed: onAdd,
-              child: Text(
-                'Add',
-                style: TextStyle(
-                  fontSize: 17,
-                  fontWeight: FontWeight.w600,
-                  color: onAdd == null
-                      ? const Color(0xFFB6B6B9)
-                      : const Color(0xFF0C79FE),
-                ),
+          Expanded(
+            child: Text(
+              title,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
               ),
             ),
+          ),
+          SizedBox(
+            width: 56,
+            child: trailingLabel == null
+                ? null
+                : Align(
+                    alignment: Alignment.centerRight,
+                    child: CupertinoButton(
+                      padding: EdgeInsets.zero,
+                      onPressed: onTrailingTap,
+                      child: Text(
+                        trailingLabel!,
+                        style: TextStyle(
+                          fontSize: 17,
+                          fontWeight: FontWeight.w600,
+                          color: onTrailingTap == null
+                              ? const Color(0xFFB6B6B9)
+                              : const Color(0xFF0C79FE),
+                        ),
+                      ),
+                    ),
+                  ),
           ),
         ],
       ),
@@ -182,26 +328,91 @@ class _RepeatRow extends StatelessWidget {
 }
 
 class _ListSelectRow extends StatelessWidget {
-  const _ListSelectRow();
+  final _CategoryItem category;
+  final VoidCallback onTap;
+
+  const _ListSelectRow({
+    required this.category,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
     return _SettingRow(
       title: 'List',
+      onTap: onTap,
       trailing: Row(
-        children: const [
-          CircleAvatar(radius: 4, backgroundColor: Color(0xFFFFA032)),
-          SizedBox(width: 6),
+        children: [
+          CircleAvatar(radius: 4, backgroundColor: category.color),
+          const SizedBox(width: 6),
           Text(
-            'Reminders',
-            style: TextStyle(color: Color(0xFF8E8E92)),
+            category.name,
+            style: const TextStyle(color: Color(0xFF8E8E92)),
           ),
-          SizedBox(width: 6),
-          Icon(Icons.chevron_right, color: Color(0xFFB6B6B9)),
+          const SizedBox(width: 6),
+          const Icon(Icons.chevron_right, color: Color(0xFFB6B6B9)),
         ],
       ),
     );
   }
+}
+
+class _CategoryListTile extends StatelessWidget {
+  final _CategoryItem category;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _CategoryListTile({
+    required this.category,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Material(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
+            child: Row(
+              children: [
+                CircleAvatar(radius: 6, backgroundColor: category.color),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    category.name,
+                    style: const TextStyle(fontSize: 16),
+                  ),
+                ),
+                if (isSelected)
+                  const Icon(
+                    Icons.check,
+                    color: Color(0xFF0C79FE),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+@immutable
+class _CategoryItem {
+  final String name;
+  final Color color;
+
+  const _CategoryItem({
+    required this.name,
+    required this.color,
+  });
 }
 
 
@@ -209,16 +420,18 @@ class _SettingRow extends StatelessWidget {
   final String title;
   final Widget trailing;
   final Color? iconColor;
+  final VoidCallback? onTap;
 
   const _SettingRow({
     required this.title,
     required this.trailing,
     this.iconColor,
+    this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    final content = Container(
       margin: const EdgeInsets.symmetric(horizontal: 16),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
       decoration: BoxDecoration(
@@ -248,5 +461,20 @@ class _SettingRow extends StatelessWidget {
         ],
       ),
     );
+
+    if (onTap == null) {
+      return content;
+    }
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onTap,
+        child: content,
+      ),
+    );
   }
 }
+
+enum _SheetMode { memo, category }


### PR DESCRIPTION
### Motivation
- Round the two top corners of the bottom sheet so it visually matches a sheet-style UI by clipping the container.
- Prevent sheet content from vertically centering when switching between memo and category views by aligning content to the top.
- Preserve a fixed sheet height so the sheet doesn't jump when changing modes.
- Keep a shared header and enable inline category selection without opening a separate dialog.

### Description
- Clip the sheet with `ClipRRect` and `BorderRadius.vertical(top: Radius.circular(20))`, and wrap the content in a `SizedBox` with `sheetHeight` to enforce a fixed height.
- Top-align the content by setting `Column(mainAxisAlignment: MainAxisAlignment.start)` and wrapping the switched content in `Align(alignment: Alignment.topCenter)` inside the `AnimatedSwitcher`.
- Replace the old header with a reusable `_SheetHeader` (leading/title/trailing API) and switch between memo/category modes via a `_SheetMode` enum and handlers ` _showCategorySheet`, `_showMemoSheet`, and `_selectCategory`.
- Refactor content into ` _MemoSheetContent` and `_CategorySheetContent`, add `_CategoryListTile` and `_CategoryItem`, and make `_ListSelectRow` and `_SettingRow` support taps and dynamic category display.

### Testing
- No automated tests were run for this change.
- Manual verification is expected during app runtime to confirm visual rounding and top alignment (not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a1e7c7b788323bd26563549ccb7ec)